### PR TITLE
Update protocol and target port list

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const fields = [
   'request',                'user_agent',               'ssl_cipher',               'ssl_protocol',
   'target_group_arn',       'trace_id',                 'domain_name',              'chosen_cert_arn',
   'matched_rule_priority',  'request_creation_time',    'actions_executed',         'redirect_url',
-  'error_reason',           'target:port_list',         'target_status_code_list',  'classification',
+  'error_reason',           'target_port_list',         'target_status_code_list',  'classification',
   'classification_reason'
 ]
 module.exports = function (line) {
@@ -125,7 +125,7 @@ function _decorateFromRequest(element, parsed) {
   parsed.request_uri = request_uri
   parsed.request_http_version = request_http_version
   const parsedUrl = url.parse(request_uri)
-  parsed.request_uri_scheme = parsedUrl.protocol
+  parsed.request_uri_scheme = parsedUrl.protocol.replace(':', '')
   parsed.request_uri_host = parsedUrl.hostname
   if (parsedUrl.port) {
     parsed.request_uri_port = parseInt(parsedUrl.port)

--- a/test.js
+++ b/test.js
@@ -48,7 +48,7 @@ tap.test('http traffic', function (t) {
     'HTTP/1.1',
     'we have request_http_version'
   )
-  t.equal(parsed.request_uri_scheme, 'http:', 'we have request_uri_scheme')
+  t.equal(parsed.request_uri_scheme, 'http', 'we have request_uri_scheme')
   t.equal(
     parsed.request_uri_host,
     'www.example.com',
@@ -102,7 +102,7 @@ tap.test('https traffic', function (t) {
   t.equal(parsed.request_method, 'GET', 'we have request_method')
   t.equal(parsed.request_uri, 'https://www.example.com:443/', 'we have request_uri')
   t.equal(parsed.request_http_version, 'HTTP/1.1', 'we have request_http_version')
-  t.equal(parsed.request_uri_scheme, 'https:', 'we have request_uri_scheme')
+  t.equal(parsed.request_uri_scheme, 'https', 'we have request_uri_scheme')
   t.equal(parsed.request_uri_host, 'www.example.com', 'we have request_uri_host')
   t.equal(parsed.request_uri_port, 443, 'we have request_uri_port')
   t.equal(parsed.request_uri_path, '/', 'we have request_uri_path')
@@ -155,7 +155,7 @@ tap.test('https traffic', function (t) {
     'HTTP/1.1',
     'we have request_http_version'
   )
-  t.equal(parsed.request_uri_scheme, 'https:', 'we have request_uri_scheme')
+  t.equal(parsed.request_uri_scheme, 'https', 'we have request_uri_scheme')
   t.equal(
     parsed.request_uri_host,
     'mytest-111.ap-northeast-1.elb.amazonaws.com',
@@ -260,7 +260,7 @@ tap.test('websockets', function (t) {
     'HTTP/1.1',
     'we have request_http_version'
   )
-  t.equal(parsed.request_uri_scheme, 'http:', 'we have request_uri_scheme')
+  t.equal(parsed.request_uri_scheme, 'http', 'we have request_uri_scheme')
   t.equal(parsed.request_uri_host, '10.0.0.30', 'we have request_uri_host')
   t.equal(parsed.request_uri_port, 80, 'we have request_uri_port')
   t.equal(parsed.request_uri_path, '/', 'we have request_uri_path')
@@ -295,7 +295,7 @@ tap.test('secure websockets', function (t) {
   t.equal(parsed.request_method, 'GET', 'we have request_method')
   t.equal(parsed.request_uri, 'https://10.0.0.30:443/', 'we have request_uri')
   t.equal(parsed.request_http_version, 'HTTP/1.1', 'we have request_http_version')
-  t.equal(parsed.request_uri_scheme, 'https:', 'we have request_uri_scheme')
+  t.equal(parsed.request_uri_scheme, 'https', 'we have request_uri_scheme')
   t.equal(parsed.request_uri_host, '10.0.0.30', 'we have request_uri_host')
   t.equal(parsed.request_uri_port, 443, 'we have request_uri_port')
   t.equal(parsed.request_uri_path, '/', 'we have request_uri_path')
@@ -325,7 +325,7 @@ tap.test('unsuccessful Lambda', function (t) {
   t.equal(parsed.request_method, 'GET', 'we have request_method')
   t.equal(parsed.request_uri, 'http://www.example.com:80/', 'we have request_uri')
   t.equal(parsed.request_http_version, 'HTTP/1.1', 'we have request_http_version')
-  t.equal(parsed.request_uri_scheme, 'http:', 'we have request_uri_scheme')
+  t.equal(parsed.request_uri_scheme, 'http', 'we have request_uri_scheme')
   t.equal(parsed.request_uri_host, 'www.example.com', 'we have request_uri_host')
   t.equal(parsed.request_uri_port, 80, 'we have request_uri_port')
   t.equal(parsed.request_uri_path, '/', 'we have request_uri_path')
@@ -367,7 +367,7 @@ tap.test('successful Lambda', function (t) {
   t.equal(parsed.request_method, 'GET', 'we have request_method')
   t.equal(parsed.request_uri, 'http://www.example.com:80/', 'we have request_uri')
   t.equal(parsed.request_http_version, 'HTTP/1.1', 'we have request_http_version')
-  t.equal(parsed.request_uri_scheme, 'http:', 'we have request_uri_scheme')
+  t.equal(parsed.request_uri_scheme, 'http', 'we have request_uri_scheme')
   t.equal(parsed.request_uri_host, 'www.example.com', 'we have request_uri_host')
   t.equal(parsed.request_uri_port, 80, 'we have request_uri_port')
   t.equal(parsed.request_uri_path, '/', 'we have request_uri_path')


### PR DESCRIPTION
I don't know if anybody else would want this but two changes here:

1. The protocol includes the "colon". For me the scheme should not include the colon and is redundant data
2. The target:port_list conflicts with another field that's parsed in using logstash (I have two concurrent processes loading data). The logstash filters use the column name "target_port_list" and it's more complicated to change that so just removing the special character from this field

Thoughts?